### PR TITLE
Add support for systems who return `aarch64` as their arch

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -34,7 +34,7 @@ get_arch() {
     amd64 | x86_64)
       echo "amd64"
       ;;
-    arm64)
+    arm64 | aarch64)
       echo "arm64"
       ;;
     *)


### PR DESCRIPTION
Some systems report `aarch64` when running `uname -m`. This adds support for those systems. Currently dagger fails to install when `uname -m` returns `aarch64`.