### PR TITLE
Filter out non CLI releases

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
-set -o pipefail
-# set -x
+set -eo pipefail
+[ -z "$DEBUG" ] || set -x
 
 ASDF_INSTALL_TYPE=${ASDF_INSTALL_TYPE:-version}
 [ -n "$ASDF_INSTALL_VERSION" ] || (>&2 echo 'Missing ASDF_INSTALL_VERSION' && exit 1)

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -eo pipefail
+[ -z "$DEBUG" ] || set -x
 
 repo=dagger/dagger
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -16,6 +16,6 @@ sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-versions=$(eval "$cmd $releases_path" | grep -oE "tag_name\":\s?\".*\"," | sed 's/tag_name\": *\"//;s/\",//' | sed 's/^[v]//' | sort_versions | xargs)
+versions=$(eval "$cmd $releases_path" | grep -oE "tag_name\":\s?\"v.*\"," | sed 's/tag_name\": *\"//;s/\",//' | sed 's/^[v]//' | sort_versions | xargs)
 
 echo "$versions"


### PR DESCRIPTION
We - @dagger/team - publish many different releases in our `dagger/dagger` repo. The only releases that are interesting for this asdf plugin are the CLI ones, which start with "v".

Before this change:

    tag_name": "v0.9.5",
    tag_name": "sdk/python/v0.9.5",
    tag_name": "sdk/php/v0.9.5",
    tag_name": "sdk/nodejs/v0.9.5",
    tag_name": "sdk/go/v0.9.5",
    tag_name": "sdk/elixir/v0.9.5",
    tag_name": "v0.9.4",
    tag_name": "sdk/python/v0.9.4",
    tag_name": "sdk/nodejs/v0.9.4",
    tag_name": "sdk/go/v0.9.4",
    tag_name": "sdk/elixir/v0.9.4",
    tag_name": "v0.9.3",
    tag_name": "sdk/python/v0.9.3",
    tag_name": "sdk/nodejs/v0.9.3",
    tag_name": "sdk/go/v0.9.3",
    tag_name": "sdk/elixir/v0.9.3",
    tag_name": "v0.9.2",
    tag_name": "sdk/python/v0.9.2",
    tag_name": "sdk/nodejs/v0.9.2",
    tag_name": "sdk/go/v0.9.2",
    tag_name": "sdk/elixir/v0.9.2",
    tag_name": "v0.9.1",
    tag_name": "sdk/python/v0.9.1",
    tag_name": "sdk/nodejs/v0.9.1",
    tag_name": "sdk/go/v0.9.1",
    tag_name": "sdk/elixir/v0.9.1",
    tag_name": "v0.9.0",
    tag_name": "sdk/python/v0.9.0",
    tag_name": "sdk/nodejs/v0.9.0",
    tag_name": "sdk/go/v0.9.0",

After this change:

    tag_name": "v0.9.5",
    tag_name": "v0.9.4",
    tag_name": "v0.9.3",
    tag_name": "v0.9.2",
    tag_name": "v0.9.1",
    tag_name": "v0.9.0",
    tag_name": "v0.8.8",

---
Thanks for creating this asdf plugin @virtualstaticvoid! I use asdf-vm too and found this useful.